### PR TITLE
Fix gcc build error.

### DIFF
--- a/include/CppLinuxSerial/SerialPort.hpp
+++ b/include/CppLinuxSerial/SerialPort.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include <asm/ioctls.h>
 #include <asm/termbits.h>
+#include <cstdint>
 
 // User headers
 #include "Exception.hpp"


### PR DESCRIPTION
Got error message in build process (GCC 13.2.1):
```
CppLinuxSerial/src/SerialPort.cpp:31:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’;
```